### PR TITLE
feat: Display shorter UUID for completion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,3 @@
-[workspace]
-members = ["rutd-cli", "rutd-core", "rutd-tui"]
-resolver = "2"
-
 [package]
 name = "rutd"
 description = "A Rust CLI tool for managing and tracking your daily tasks. Git-friendly and easy to use."
@@ -14,24 +10,9 @@ authors.workspace = true
 repository.workspace = true
 license.workspace = true
 
-[dependencies]
-rutd-cli = { path = "rutd-cli", version = "0.6.2" }
-# rutd-tui = { path = "rutd-tui", version = "0.2.1-rc.3" }
-
-[features]
-default = []
-vendored = ["rutd-cli/vendored"]
-
-[profile.release]
-strip = true
-lto = true
-
-[[bin]]
-name = "rutd-cli"
-path = "src/cli.rs"
-# [[bin]]
-# name = "rutd-tui"
-# path = "src/bin/tui.rs"
+[workspace]
+members = ["rutd-cli", "rutd-core", "rutd-tui"]
+resolver = "2"
 
 [workspace.package]
 version = "0.6.2"
@@ -59,6 +40,25 @@ strum = { version = "0.27.1", features = ["derive"] }
 tempfile = "3.19.1"
 toml = "0.8.8"
 uuid = { version = "1.6.1", features = ["v4"] }
+
+[[bin]]
+name = "rutd-cli"
+path = "src/cli.rs"
+# rutd-tui = { path = "rutd-tui", version = "0.2.1-rc.3" }
+# [[bin]]
+# name = "rutd-tui"
+# path = "src/bin/tui.rs"
+
+[features]
+default = []
+vendored = ["rutd-cli/vendored"]
+
+[dependencies]
+rutd-cli = { path = "rutd-cli", version = "0.6.2" }
+
+[profile.release]
+strip = true
+lto = true
 
 [lints.clippy]
 nursery = "warn"

--- a/rutd-cli/Cargo.toml
+++ b/rutd-cli/Cargo.toml
@@ -8,6 +8,11 @@ repository.workspace = true
 license.workspace = true
 readme.workspace = true
 
+[features]
+default = []
+debug = ["clap_complete/debug"]
+vendored = ["rutd-core/vendored"]
+
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
@@ -23,11 +28,6 @@ simple_logger.workspace = true
 strum.workspace = true
 tempfile.workspace = true
 toml.workspace = true
-
-[features]
-default = []
-debug = ["clap_complete/debug"]
-vendored = ["rutd-core/vendored"]
 
 [profile.release]
 strip = true

--- a/rutd-cli/src/completer/task_attribute.rs
+++ b/rutd-cli/src/completer/task_attribute.rs
@@ -224,18 +224,17 @@ mod tests {
         // Test with the prefix of the long ID
         let completions = complete_id(OsStr::new("longid"));
         assert_eq!(completions.len(), 1);
-        assert_eq!(completions[0].value(), "longid12");
+        assert_eq!(completions[0].get_value(), "longid12");
 
         // Test with the full long ID as prefix (should still truncate)
         let completions_full = complete_id(OsStr::new("longid12345"));
         assert_eq!(completions_full.len(), 1);
-        assert_eq!(completions_full[0].value(), "longid12");
-        
+        assert_eq!(completions_full[0].get_value(), "longid12");
+
         // Test with a short ID that should not be truncated
         let completions_short = complete_id(OsStr::new("task-123"));
         assert_eq!(completions_short.len(), 1);
-        assert_eq!(completions_short[0].value(), "task-123");
-
+        assert_eq!(completions_short[0].get_value(), "task-123");
 
         cleanup_env_vars(&env_vars);
         drop(temp_dir);

--- a/rutd-cli/src/completer/task_attribute.rs
+++ b/rutd-cli/src/completer/task_attribute.rs
@@ -30,7 +30,8 @@ pub fn complete_id(current: &OsStr) -> Vec<CompletionCandidate> {
         .map(|task| {
             // Take the first line of the task description as help text
             let short_description = task.description.lines().next().map(String::from);
-            CompletionCandidate::new(task.id).help(short_description.map(StyledStr::from))
+            let truncated_id = task.id.chars().take(8).collect::<String>();
+            CompletionCandidate::new(truncated_id).help(short_description.map(StyledStr::from))
         })
         .collect()
 }
@@ -206,6 +207,38 @@ mod tests {
                 env::remove_var(key);
             }
         }
+    }
+
+    #[test]
+    fn test_complete_id_truncation() {
+        let (temp_dir, env_vars) = setup_test_env();
+        let task_dir = temp_dir.path().join("tasks");
+
+        // Create a task with a long ID
+        let long_id_task = create_test_task("longid12345", Some("test"), Some("truncation"));
+        let file_path = task_dir.join(format!("{}.toml", long_id_task.id));
+        let toml_string = toml::to_string(&long_id_task).unwrap();
+        let mut file = File::create(file_path).unwrap();
+        file.write_all(toml_string.as_bytes()).unwrap();
+
+        // Test with the prefix of the long ID
+        let completions = complete_id(OsStr::new("longid"));
+        assert_eq!(completions.len(), 1);
+        assert_eq!(completions[0].value(), "longid12");
+
+        // Test with the full long ID as prefix (should still truncate)
+        let completions_full = complete_id(OsStr::new("longid12345"));
+        assert_eq!(completions_full.len(), 1);
+        assert_eq!(completions_full[0].value(), "longid12");
+        
+        // Test with a short ID that should not be truncated
+        let completions_short = complete_id(OsStr::new("task-123"));
+        assert_eq!(completions_short.len(), 1);
+        assert_eq!(completions_short[0].value(), "task-123");
+
+
+        cleanup_env_vars(&env_vars);
+        drop(temp_dir);
     }
 
     #[test]

--- a/rutd-core/Cargo.toml
+++ b/rutd-core/Cargo.toml
@@ -8,6 +8,10 @@ repository.workspace = true
 license.workspace = true
 readme.workspace = true
 
+[features]
+default = []
+vendored = ["git2/vendored-openssl", "git2/vendored-libgit2"]
+
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
@@ -22,10 +26,6 @@ strum.workspace = true
 tempfile.workspace = true
 toml.workspace = true
 uuid.workspace = true
-
-[features]
-default = []
-vendored = ["git2/vendored-openssl", "git2/vendored-libgit2"]
 
 [profile.release]
 strip = true


### PR DESCRIPTION
The task ID in completion suggestions is now truncated to the first 8 characters. This provides a more concise display while still offering enough uniqueness for completion.